### PR TITLE
Functions to enable a limited form of "outside the SDF is lava" handling of the boundary

### DIFF
--- a/include/sdf_tools/sdf.hpp
+++ b/include/sdf_tools/sdf.hpp
@@ -165,6 +165,18 @@ namespace sdf_tools
 
         Eigen::Vector4d ProjectOutOfCollisionToMinimumDistance4d(const Eigen::Vector4d& location, const double minimum_distance, const double stepsize_multiplier = 1.0 / 8.0) const;
 
+        Eigen::Vector3d ProjectIntoValidVolume(const double x, const double y, const double z) const;
+
+        Eigen::Vector3d ProjectIntoValidVolumeToMinimumDistance(const double x, const double y, const double z, const double minimum_distance) const;
+
+        Eigen::Vector3d ProjectIntoValidVolume3d(const Eigen::Vector3d& location) const;
+
+        Eigen::Vector3d ProjectIntoValidVolumeToMinimumDistance3d(const Eigen::Vector3d& location, const double minimum_distance) const;
+
+        Eigen::Vector4d ProjectIntoValidVolume4d(const Eigen::Vector4d& location) const;
+
+        Eigen::Vector4d ProjectIntoValidVolumeToMinimumDistance4d(const Eigen::Vector4d& location, const double minimum_distance) const;
+
         const Eigen::Isometry3d& GetOriginTransform() const;
 
         const Eigen::Isometry3d& GetInverseOriginTransform() const;

--- a/include/sdf_tools/sdf.hpp
+++ b/include/sdf_tools/sdf.hpp
@@ -136,6 +136,13 @@ namespace sdf_tools
 
         std::pair<double, bool> EstimateDistance4d(const Eigen::Vector4d& location) const;
 
+        // Estimate the distance between the given point and the outer boundary of the SDF
+        std::pair<double, bool> DistanceToBoundary(const double x, const double y, const double z) const;
+
+        std::pair<double, bool> DistanceToBoundary3d(const Eigen::Vector3d& location) const;
+
+        std::pair<double, bool> DistanceToBoundary4d(const Eigen::Vector4d& location) const;
+
         std::vector<double> GetGradient(const double x, const double y, const double z, const bool enable_edge_gradients = false) const;
 
         std::vector<double> GetGradient3d(const Eigen::Vector3d& location, const bool enable_edge_gradients = false) const;

--- a/src/sdf_tools/sdf.cpp
+++ b/src/sdf_tools/sdf.cpp
@@ -631,9 +631,9 @@ namespace sdf_tools
         const auto y_size = distance_field_.GetYSize();
         const auto z_size = distance_field_.GetZSize();
         const auto displacements = Eigen::Array3d(
-                    point_in_grid_frame(0) <= x_size * 0.5 ? point_in_grid_frame(0) : x_size - point_in_grid_frame(0),
-                    point_in_grid_frame(1) <= y_size * 0.5 ? point_in_grid_frame(1) : y_size - point_in_grid_frame(1),
-                    point_in_grid_frame(2) <= z_size * 0.5 ? point_in_grid_frame(2) : z_size - point_in_grid_frame(2));
+                    std::min(point_in_grid_frame(0), x_size - point_in_grid_frame(0)),
+                    std::min(point_in_grid_frame(1), y_size - point_in_grid_frame(1)),
+                    std::min(point_in_grid_frame(2), z_size - point_in_grid_frame(2)));
         const bool point_inside = (displacements >= 0.0).all();
         const Eigen::Array3d distances = displacements.abs();
         Eigen::Array3d::Index min_index;

--- a/src/sdf_tools/sdf.cpp
+++ b/src/sdf_tools/sdf.cpp
@@ -613,6 +613,34 @@ namespace sdf_tools
         }
     }
 
+    std::pair<double, bool> SignedDistanceField::DistanceToBoundary(const double x, const double y, const double z) const
+    {
+        return DistanceToBoundary4d(Eigen::Vector4d(x, y, z, 1.0));
+    }
+
+    std::pair<double, bool> SignedDistanceField::DistanceToBoundary3d(const Eigen::Vector3d& location) const
+    {
+        return DistanceToBoundary4d(Eigen::Vector4d(location.x(), location.y(), location.z(), 1.0));
+    }
+
+    std::pair<double, bool> SignedDistanceField::DistanceToBoundary4d(const Eigen::Vector4d& location) const
+    {
+        const auto inverse_origin_transform = distance_field_.GetInverseOriginTransform();
+        const auto point_in_grid_frame = inverse_origin_transform * location;
+        const auto x_size = distance_field_.GetXSize();
+        const auto y_size = distance_field_.GetYSize();
+        const auto z_size = distance_field_.GetZSize();
+        const Eigen::Array3d displacements(
+                    point_in_grid_frame(0) <= x_size * 0.5 ? point_in_grid_frame(0) : x_size - point_in_grid_frame(0),
+                    point_in_grid_frame(1) <= y_size * 0.5 ? point_in_grid_frame(1) : y_size - point_in_grid_frame(1),
+                    point_in_grid_frame(2) <= z_size * 0.5 ? point_in_grid_frame(2) : z_size - point_in_grid_frame(2));
+        const bool point_inside = (displacements >= 0.0).all();
+        const Eigen::Array3d distances = displacements.abs();
+        Eigen::Array3d::Index min_index;
+        distances.minCoeff(&min_index);
+        return {displacements(min_index), point_inside};
+    }
+
     std::vector<double> SignedDistanceField::GetGradient(const double x, const double y, const double z, const bool enable_edge_gradients) const
     {
         return GetGradient4d(Eigen::Vector4d(x, y, z, 1.0), enable_edge_gradients);
@@ -755,8 +783,16 @@ namespace sdf_tools
         // here that we can change. https://eigen.tuxfamily.org/dox/group__TopicPassingByValue.html
         Eigen::Vector4d mutable_location = location;
 
+        // Verify that the input location is in bounds
+        const auto distance_check = EstimateDistance4d(location);
+        if (!distance_check.second)
+        {
+            std::cerr << "starting location out of bounds: " << location.transpose() << std::endl;
+            std::cerr << std::endl << std::endl;
+        }
+
         // If we are in bounds, start the projection process, otherwise return the location unchanged
-        if (CheckInBounds4d(mutable_location))
+        if (distance_check.second)
         {
             // Add a small collision margin to account for rounding and similar
             const double minimum_distance_with_margin = minimum_distance + GetResolution() * stepsize_multiplier * 1e-3;
@@ -772,8 +808,20 @@ namespace sdf_tools
                 assert(grad_eigen.norm() > GetResolution() * 0.25); // Sanity check
                 // Don't step any farther than is needed
                 const double step_distance = std::min(max_stepsize, minimum_distance_with_margin - sdf_dist);
-                mutable_location += grad_eigen.normalized() * step_distance;
-                sdf_dist = EstimateDistance4d(mutable_location).first;
+                const Eigen::Vector4d next_location = mutable_location + grad_eigen.normalized() * step_distance;
+
+                // Ensure that we are still operating in the valid range of the SDF
+                const auto distance_check = EstimateDistance4d(next_location);
+                if (!distance_check.second)
+                {
+                    std::cerr << "starting location: " << location.transpose() << std::endl
+                              << "current location:  " << mutable_location.transpose() << std::endl
+                              << "Current gradient:  " << grad_eigen.transpose() << std::endl
+                              << "Out of bounds loc: " << next_location.transpose() << std::endl;
+                    std::cerr << std::endl << std::endl;
+                }
+                mutable_location = next_location;
+                sdf_dist = distance_check.first;
             }
         }
         return mutable_location;


### PR DESCRIPTION
Essentially this gives a way to treat anything outside the SDF as an obstacle, without explicitly handling this case in the SDF builder, or breaking existing code. These functions would need to be invoked separately if the functionality is wanted for a given usage.