### PR TITLE
Enable CollisionMap origin/frame updates

### DIFF
--- a/include/sdf_tools/collision_map.hpp
+++ b/include/sdf_tools/collision_map.hpp
@@ -123,7 +123,13 @@ namespace sdf_tools
 
         const Eigen::Isometry3d& GetInverseOriginTransform() const;
 
+        void SetOriginTransform(const Eigen::Isometry3d& new_origin);
+
+        void SetInverseOriginTransform(const Eigen::Isometry3d& new_inverse_origin);
+
         std::string GetFrame() const;
+
+        void SetFrame(const std::string& frame);
 
         std::pair<uint32_t, bool> GetNumConnectedComponents() const;
 

--- a/include/sdf_tools/sdf.hpp
+++ b/include/sdf_tools/sdf.hpp
@@ -40,7 +40,7 @@ namespace sdf_tools
 
         SignedDistanceField(std::string frame, double resolution, double x_size, double y_size, double z_size, float OOB_value);
 
-        SignedDistanceField(Eigen::Isometry3d origin_transform, std::string frame, double resolution, double x_size, double y_size, double z_size, float OOB_value);
+        SignedDistanceField(const Eigen::Isometry3d& origin_transform, std::string frame, double resolution, double x_size, double y_size, double z_size, float OOB_value);
 
         SignedDistanceField();
 

--- a/src/sdf_tools/collision_map.cpp
+++ b/src/sdf_tools/collision_map.cpp
@@ -533,9 +533,26 @@ namespace sdf_tools
         return collision_field_.GetInverseOriginTransform();
     }
 
+    void CollisionMapGrid::SetOriginTransform(const Eigen::Isometry3d& new_origin)
+    {
+        collision_field_.SetOriginTransform(new_origin);
+        collision_field_.SetInverseOriginTransform(new_origin.inverse());
+    }
+
+    void CollisionMapGrid::SetInverseOriginTransform(const Eigen::Isometry3d& new_inverse_origin)
+    {
+        collision_field_.SetInverseOriginTransform(new_inverse_origin);
+        collision_field_.SetOriginTransform(new_inverse_origin.inverse());
+    }
+
     std::string CollisionMapGrid::GetFrame() const
     {
         return frame_;
+    }
+
+    void CollisionMapGrid::SetFrame(const std::string& new_frame)
+    {
+        frame_ = new_frame;
     }
 
     std::pair<uint32_t, bool> CollisionMapGrid::GetNumConnectedComponents() const

--- a/src/sdf_tools/sdf.cpp
+++ b/src/sdf_tools/sdf.cpp
@@ -196,7 +196,7 @@ namespace sdf_tools
         distance_field_ = new_field;
     }
 
-    SignedDistanceField::SignedDistanceField(Eigen::Isometry3d origin_transform, std::string frame, double resolution, double x_size, double y_size, double z_size, float OOB_value)
+    SignedDistanceField::SignedDistanceField(const Eigen::Isometry3d& origin_transform, std::string frame, double resolution, double x_size, double y_size, double z_size, float OOB_value)
         : initialized_(true), locked_(false)
     {
         frame_ = frame;


### PR DESCRIPTION
Added ability to change the origin transform of a collision map after it has been created.